### PR TITLE
fixed a typo in ../project_config.js

### DIFF
--- a/app/templates/gulp-tasks/helpers/common/project_config.js
+++ b/app/templates/gulp-tasks/helpers/common/project_config.js
@@ -25,7 +25,7 @@
 
             let loadedData = getConfigData(configFileName);
 
-            if(typeof loadedData.general === 'undeinfed'){
+            if(typeof loadedData.general === 'undefined'){
                 throw new Error('general section of conifg file is required, filename = ' + configFileName);
             }
 


### PR DESCRIPTION
There was a typo in this template.
Found **undeinfed** instead of **_undefined_**.