### PR TITLE
[CORE-1845] deploys to dev/staging to use '(qa/branch)/(qa/tag)' in the deploy path by default.

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -746,6 +746,7 @@
                 dependencies = dependencies.concat([
                     'gulp-awspublish@^3.3.0',
                     'gulp-awspublish-router@^0.1.2',
+                    'git-rev-sync@1.9.1',
                     'git-user-email@0.2.1',
                     'git-user-name@^1.2.0',
                     'gulp-slack@^0.1.2',

--- a/app/templates/gulp-tasks/helpers/common/args.js
+++ b/app/templates/gulp-tasks/helpers/common/args.js
@@ -3,7 +3,7 @@
 
     var argv = require('yargs').argv;
 
-    var allowedOptions = ['env', 'localSdk', 'uglify', 'deployVersion'];
+    var allowedOptions = ['env', 'localSdk', 'uglify', 'deployVersion', 'noQa'];
 
     validateAllowedOptions();
 

--- a/app/templates/gulp-tasks/tasks-config/bb-dev/deploy_aws.js
+++ b/app/templates/gulp-tasks/tasks-config/bb-dev/deploy_aws.js
@@ -81,7 +81,7 @@
                     let currentBranch = gitRevSync.branch();
                     let currentTag = gitRevSync.tag();
                     let currentBanchOrTag = '';
-                    if (currentBranch.match(/detached/i)) {
+                    if (currentBranch.match(/Detached/i)) {
                         currentBanchOrTag = currentTag;
                     } else currentBanchOrTag = currentBranch;
                     path.dirname = configuration.projectConfig.build.deploy_path + currentBanchOrTag + '/' + path.dirname;

--- a/app/templates/gulp-tasks/tasks-config/bb-dev/deploy_aws.js
+++ b/app/templates/gulp-tasks/tasks-config/bb-dev/deploy_aws.js
@@ -2,7 +2,9 @@
     'use strict';
 
     const argv = require('yargs').argv;
+    const args = require('../helpers/args');
     const fs = require('fs');
+    const gitRevSync = require('git-rev-sync');
     const gitUserEmail = require('git-user-email');
     const gitUserName = require('git-user-name');
     const gulpAwsPublish = require('gulp-awspublish');
@@ -73,7 +75,17 @@
          */
         function renameReleaseFiles() {
             return gulpRename(function (path) {
-                path.dirname = configuration.projectConfig.build.deploy_path + path.dirname;
+                if (args.getEnvironment() === 'prod') {
+                    path.dirname = configuration.projectConfig.build.deploy_path + path.dirname;
+                } else {
+                    let currentBranch = gitRevSync.branch();
+                    let currentTag = gitRevSync.tag();
+                    let currentBanchOrTag = '';
+                    if (currentBranch.match(/detached/i)) {
+                        currentBanchOrTag = currentTag;
+                    } else currentBanchOrTag = currentBranch;
+                    path.dirname = configuration.projectConfig.build.deploy_path + currentBanchOrTag + '/' + path.dirname;
+                }
             });
         }
 

--- a/app/templates/gulp-tasks/tasks-config/bb-dev/deploy_aws.js
+++ b/app/templates/gulp-tasks/tasks-config/bb-dev/deploy_aws.js
@@ -53,8 +53,9 @@
 
         function consoleNotificationAboutDeployment() {
             let sdkVersion = configuration.projectConfig.build.sdk_version === null ? 'unreleased version' : 'version ' + configuration.projectConfig.build.sdk_version;
+            if (!(argv.noQa || args.getEnvironment() === 'prod')) configuration.projectConfig.build.deploy_version = getCurrentBranchOrTag();
             let projectVersion = configuration.projectConfig.build.deploy_version === false ? 'unreleased version' : 'version ' + configuration.projectConfig.build.deploy_version;
-            let msg = "Deploying to " + configuration.environment + " with SDK " + sdkVersion + ", PROJECT " +  projectVersion;
+            let msg = "Deploying to " + configuration.environment + " with SDK " + sdkVersion + ", PROJECT " + projectVersion;
             gulpUtil.log(gulpUtil.colors.green(msg));
         }
 
@@ -78,11 +79,7 @@
                 if (argv.noQa || args.getEnvironment() === 'prod') {
                     path.dirname = configuration.projectConfig.build.deploy_path + path.dirname;
                 } else {
-                    let currentBranch = gitRevSync.branch();
-                    let currentTag = gitRevSync.tag();
-                    let currentBanchOrTag = '';
-                    if (currentBranch.match(/Detached/i)) currentBanchOrTag = currentTag;
-                    else currentBanchOrTag = currentBranch;
+                    let currentBanchOrTag = getCurrentBranchOrTag();
                     path.dirname = configuration.projectConfig.build.deploy_path + 'qa/' + currentBanchOrTag + '/' + path.dirname;
                 }
             });
@@ -142,6 +139,19 @@
             } else {
                 return mail;
             }
+        }
+
+        /**
+         * @returns {String}
+         */
+        function getCurrentBranchOrTag() {
+            let currentBranch = gitRevSync.branch();
+            let currentTag = gitRevSync.tag();
+            let currentBanchOrTag = '';
+            if (currentBranch.match(/detached/i)) {
+                currentBanchOrTag = currentTag;
+            } else currentBanchOrTag = currentBranch;
+            return currentBanchOrTag;
         }
 
         /**

--- a/app/templates/gulp-tasks/tasks-config/bb-dev/deploy_aws.js
+++ b/app/templates/gulp-tasks/tasks-config/bb-dev/deploy_aws.js
@@ -75,16 +75,15 @@
          */
         function renameReleaseFiles() {
             return gulpRename(function (path) {
-                if (args.getEnvironment() === 'prod') {
+                if (argv.noQa || args.getEnvironment() === 'prod') {
                     path.dirname = configuration.projectConfig.build.deploy_path + path.dirname;
                 } else {
                     let currentBranch = gitRevSync.branch();
                     let currentTag = gitRevSync.tag();
                     let currentBanchOrTag = '';
-                    if (currentBranch.match(/Detached/i)) {
-                        currentBanchOrTag = currentTag;
-                    } else currentBanchOrTag = currentBranch;
-                    path.dirname = configuration.projectConfig.build.deploy_path + currentBanchOrTag + '/' + path.dirname;
+                    if (currentBranch.match(/Detached/i)) currentBanchOrTag = currentTag;
+                    else currentBanchOrTag = currentBranch;
+                    path.dirname = configuration.projectConfig.build.deploy_path + 'qa/' + currentBanchOrTag + '/' + path.dirname;
                 }
             });
         }


### PR DESCRIPTION
**Change Note:**
- [CORE-1845] enhance front-end deploys to dev and staging envs to use  '(qa/branch)/(qa/tag)' in the deploy path by default.
- [CORE-1845] add in '--noQa' option as '--noQa true' for deploys without 'qa/'.