### PR TITLE
additional modules injection during the generation process

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -80,7 +80,6 @@
             message: 'Please choose types of user journeys you want to create',
             choices: publicBookingOptions
         }, function (response) {
-
             if (response.type.length === 0) {
 
                 publicBookingOptions.map(function (option) {
@@ -633,7 +632,30 @@
                 );
             }
 
-            let templateOptions = {module_name: camelCase(this.appName)};
+
+            /**
+             * We need to catch if the user adds a member journey type to the generation process,
+             * so we check if in the selected options there is a member option.
+             *
+             * The regex/string comparison may sound a bit weak, but it's the only solution I found
+             */
+            let isMemberJourney = this.publicBookingOptionsSelected.filter(function(opt) {
+                return opt.match(/member/gi)
+            }).length > 0;
+
+            // Additional modules to inject inside main.module file (config function)
+            let modules = [];
+
+            // inject BBmember if the user selects a member journey
+            if (isMemberJourney) {
+                modules.push('BBMember');
+            }
+
+            // pass module_name itself to templates and the additional modules to inject
+            let templateOptions = {
+                module_name: camelCase(this.appName),
+                modules: modules
+            };
 
             this.template(
                 path.join(this.type, 'src', 'javascripts'),

--- a/app/templates/public-booking/src/javascripts/main.module.js
+++ b/app/templates/public-booking/src/javascripts/main.module.js
@@ -1,9 +1,11 @@
 (function (angular) {
     'use strict';
-
     angular.module('<%= module_name %>', [
         'BB',
         'TemplateOverrides',
+        <% for (let i = 0; i < modules.length; i++) {%>
+        '<%= modules[i] %>',
+        <% } %>
         '<%= module_name %>.version'
     ]);
 


### PR DESCRIPTION
During the generation process, when the user selected a Member Journey, this option was ignored. 
Now additional modules can be injected inside the main.module file.

For this specific case I look if the member option has been added to the option list; if true, a 'BBMember' module is added to the module list and then is passed to the template.
In the template itself (main.module.js) an iteration prints out all the modules to be injected inside the config function.